### PR TITLE
Enable tag searching in model metadata

### DIFF
--- a/StabilityMatrix.Avalonia/ViewModels/CheckpointsPageViewModel.cs
+++ b/StabilityMatrix.Avalonia/ViewModels/CheckpointsPageViewModel.cs
@@ -213,6 +213,15 @@ public partial class CheckpointsPageViewModel(
                     (Func<LocalModelFile, bool>)(
                         file =>
                             string.IsNullOrWhiteSpace(SearchQuery)
+                            || (
+                                SearchQuery.StartsWith("#")
+                                && (
+                                    file.ConnectedModelInfo?.Tags.Contains(
+                                        SearchQuery.Substring(1),
+                                        StringComparer.OrdinalIgnoreCase
+                                    ) ?? false
+                                )
+                            )
                             || file.DisplayModelFileName.Contains(
                                 SearchQuery,
                                 StringComparison.OrdinalIgnoreCase


### PR DESCRIPTION
Added the ability to search for tags (exact, case-insensitive) using the # operator. For example: #celebrity will return all models with the Celebrity tag #celebrit will return nothing